### PR TITLE
modern versions of qthreads provide qthread/qthread.h not qthread.h

### DIFF
--- a/qthreads/src/SparseMatrix_functions.hpp
+++ b/qthreads/src/SparseMatrix_functions.hpp
@@ -49,7 +49,7 @@
 #endif
 
 #include <qthread/qloop.h>
-#include <qthread.h>
+#include <qthread/qthread.h>
 #include "qthreads_loop_type.h"
 
 namespace miniFE {

--- a/qthreads/src/Vector_functions.hpp
+++ b/qthreads/src/Vector_functions.hpp
@@ -41,7 +41,7 @@
 #include <Vector.hpp>
 
 #include <qthread/qloop.h>
-#include <qthread.h>
+#include <qthread/qthread.h>
 #include "qthreads_loop_type.h"
 
 namespace miniFE {

--- a/qthreads/src/main.cpp
+++ b/qthreads/src/main.cpp
@@ -48,7 +48,7 @@
 #include <YAML_Doc.hpp>
 #include <param_utils.hpp>
 
-#include <qthread.h>
+#include <qthread/qthread.h>
 
 #if MINIFE_INFO != 0
 #include <miniFE_info.hpp>


### PR DESCRIPTION
Quick change to get MiniFE compiling with newer versions of Qthreads.