### PR TITLE
Hughes/makefiles

### DIFF
--- a/openmp-opt-knl-memkind/src/Makefile.intel.openmp
+++ b/openmp-opt-knl-memkind/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-OPENMP=-qopenmp
+OPENMP=-fopenmp
 CFLAGS = -O3 $(OPENMP) -restrict -mavx
 CXXFLAGS = $(CFLAGS)
 

--- a/openmp-opt-knl-memkind/src/Makefile.intel.openmp
+++ b/openmp-opt-knl-memkind/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-OPENMP=-openmp
+OPENMP=-qopenmp
 CFLAGS = -O3 $(OPENMP) -restrict -mavx
 CXXFLAGS = $(CFLAGS)
 

--- a/openmp-opt-knl/src/Makefile.intel.openmp
+++ b/openmp-opt-knl/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-OPENMP=-qopenmp
+OPENMP=-fopenmp
 CFLAGS = -O3 $(OPENMP) -restrict -mavx
 CXXFLAGS = $(CFLAGS)
 

--- a/openmp-opt-knl/src/Makefile.intel.openmp
+++ b/openmp-opt-knl/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-OPENMP=-openmp
+OPENMP=-qopenmp
 CFLAGS = -O3 $(OPENMP) -restrict -mavx
 CXXFLAGS = $(CFLAGS)
 

--- a/openmp-opt/src/Makefile.intel.openmp
+++ b/openmp-opt/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-OPENMP=-qopenmp
+OPENMP=-fopenmp
 CFLAGS = -O3 $(OPENMP) -restrict -mavx
 CXXFLAGS = $(CFLAGS)
 

--- a/openmp-opt/src/Makefile.intel.openmp
+++ b/openmp-opt/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-OPENMP=-openmp
+OPENMP=-qopenmp
 CFLAGS = -O3 $(OPENMP) -restrict -mavx
 CXXFLAGS = $(CFLAGS)
 

--- a/openmp/src/Makefile.intel.openmp
+++ b/openmp/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-CFLAGS = -O3 -qopenmp
+CFLAGS = -O3 -fopenmp
 CXXFLAGS = $(CFLAGS)
 
 CPPFLAGS = -I. -I../utils -I../fem $(MINIFE_TYPES) $(MINIFE_MATRIX_TYPE)

--- a/openmp/src/Makefile.intel.openmp
+++ b/openmp/src/Makefile.intel.openmp
@@ -16,7 +16,7 @@ MINIFE_MATRIX_TYPE = -DMINIFE_CSR_MATRIX
 
 #-----------------------------------------------------------------------
 
-CFLAGS = -O3 -fopenmp
+CFLAGS = -O3 -qopenmp
 CXXFLAGS = $(CFLAGS)
 
 CPPFLAGS = -I. -I../utils -I../fem $(MINIFE_TYPES) $(MINIFE_MATRIX_TYPE)


### PR DESCRIPTION
openmp flag deprecated. Recommended use is qopenmp but fopenmp has backward compatibility.