### PR TITLE
fix overlapping send and recv buffers

### DIFF
--- a/cilk/basic/make_local_matrix.hpp
+++ b/cilk/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/cilk/src/make_local_matrix.hpp
+++ b/cilk/src/make_local_matrix.hpp
@@ -256,9 +256,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/cuda/basic/make_local_matrix.hpp
+++ b/cuda/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/cuda/src/make_local_matrix.hpp
+++ b/cuda/src/make_local_matrix.hpp
@@ -487,9 +487,10 @@ make_local_matrix(MatrixType& A)
   int MPI_MY_TAG = 99;
 
   nvtxRangeId_t r4=nvtxRangeStartA("MPI Communication");
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/kokkos/src/make_local_matrix.hpp
+++ b/kokkos/src/make_local_matrix.hpp
@@ -252,9 +252,10 @@ make_local_matrix(MatrixType& A)
   // wait call below.
   //
   int MPI_MY_TAG = 99;
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/mkl/basic/make_local_matrix.hpp
+++ b/mkl/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/mkl/src/make_local_matrix.hpp
+++ b/mkl/src/make_local_matrix.hpp
@@ -256,9 +256,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/nvamg/basic/make_local_matrix.hpp
+++ b/nvamg/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/nvamg/src/make_local_matrix.hpp
+++ b/nvamg/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp-opt-knl-memkind/src/make_local_matrix.hpp
+++ b/openmp-opt-knl-memkind/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp-opt-knl/basic/make_local_matrix.hpp
+++ b/openmp-opt-knl/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp-opt-knl/src/make_local_matrix.hpp
+++ b/openmp-opt-knl/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp-opt/basic/make_local_matrix.hpp
+++ b/openmp-opt/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp-opt/src/make_local_matrix.hpp
+++ b/openmp-opt/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp/basic/make_local_matrix.hpp
+++ b/openmp/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp/src/make_local_matrix.hpp
+++ b/openmp/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp45-opt/src/make_local_matrix.hpp
+++ b/openmp45-opt/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp45/basic/make_local_matrix.hpp
+++ b/openmp45/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/openmp45/src/make_local_matrix.hpp
+++ b/openmp45/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/qthreads/basic/make_local_matrix.hpp
+++ b/qthreads/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/qthreads/src/make_local_matrix.hpp
+++ b/qthreads/src/make_local_matrix.hpp
@@ -256,9 +256,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/ref/basic/make_local_matrix.hpp
+++ b/ref/basic/make_local_matrix.hpp
@@ -251,9 +251,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 

--- a/ref/src/make_local_matrix.hpp
+++ b/ref/src/make_local_matrix.hpp
@@ -254,9 +254,10 @@ make_local_matrix(MatrixType& A)
   //
   int MPI_MY_TAG = 99;
 
+  std::vector<GlobalOrdinal> tmp_recv_buffer(num_send_neighbors);
   std::vector<MPI_Request> request(num_send_neighbors);
   for(int i=0; i<num_send_neighbors; ++i) {
-    MPI_Irecv(&tmp_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
+    MPI_Irecv(&tmp_recv_buffer[i], 1, mpi_dtype, MPI_ANY_SOURCE, MPI_MY_TAG,
               MPI_COMM_WORLD, &request[i]);
   }
 


### PR DESCRIPTION
Fixes #18 overlapping send and recv buffers.  Now different buffers for MPI send and Irecv are used that happen at the same time.

I compiled and tested only a limited subset of the compilation targets.  The ones I tested look good so far:


* `ref/src`
  * gcc 11.2.0
  * Intel(R) MPI Library for Linux* OS, Version 2021.7
  * ITAC 2021.6.0
  * command: `make clean && make -j && mpiexec -n 72 -check-mpi ./miniFE.x verify_solution=1 nx=10`
  * result:

        solution matches analytic solution to within 0.06 or better.
        [0] INFO: Error checking completed without finding any problems.


* `openmp/src`
  * gcc 11.2.0
  * Intel(R) MPI Library for Linux* OS, Version 2021.7
  * ITAC 2021.6.0
  * command: `make clean && make -j && OMP_NUM_THREADS=10 mpiexec -n 2 -check-mpi ./miniFE.x verify_solution=1 nx=10`
  * result:

        solution matches analytic solution to within 0.06 or better.
        [0] INFO: Error checking completed without finding any problems.

* `mkl/src`
  * icpc (ICC) 2021.6.0 20220226
  * Intel(R) MPI Library for Linux* OS, Version 2021.7
  * ITAC 2021.6.0
  * MKL 2022.1.0
  * command: `make clean && make -j && mpiexec -n 72 -check-mpi ./miniFE.x verify_solution=1 nx=10`
  * result:

        solution matches analytic solution to within 0.06 or better.
        [0] INFO: Error checking completed without finding any problems.

Let me know if you need more testing or don't see the changes fit.