### PR TITLE
Add CI comparing `ref/` and `kokkos/`

### DIFF
--- a/.github/workflows/compare-ref-kokkos.yml
+++ b/.github/workflows/compare-ref-kokkos.yml
@@ -1,0 +1,96 @@
+name: Compare Ref And Kokkos Implementations
+
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+jobs:
+  serial-openmpi:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        case:
+          - nx: 1
+            ny: 1
+            nz: 2
+          - nx: 17
+            ny: 3
+            nz: 5
+          - nx: 20
+            ny: 30
+            nz: 40
+    name: serial-openmpi ${{ matrix.case.nx }} x ${{ matrix.case.ny }} x ${{ matrix.case.nz }}
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Check Out Kokkos
+        uses: actions/checkout@v6
+        with:
+          repository: kokkos/kokkos
+          ref: 3.7.02
+          path: external/kokkos
+
+      - name: Install MPI
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y openmpi-bin libopenmpi-dev
+
+      - name: Build ref with MINIFE_DEBUG
+        env:
+          JOBS: 2
+        run: |
+          make -C ref/src realclean
+          make -C ref/src -j$(nproc) CXXFLAGS='-O3 -DMINIFE_DEBUG'
+
+      - name: Run ref debug cases
+        run: |
+          rm -f ./*.mtx.* ./*.vec.*
+          ./ref/src/miniFE.x nx=${{ matrix.case.nx }} ny=${{ matrix.case.ny }} nz=${{ matrix.case.nz }}
+          mpirun -np 2 ./ref/src/miniFE.x nx=${{ matrix.case.nx }} ny=${{ matrix.case.ny }} nz=${{ matrix.case.nz }}
+
+      - name: Collect ref dumps
+        run: |
+          rm -rf ref-dumps
+          mkdir -p ref-dumps
+          find . -maxdepth 1 -type f \
+            \( -name '*.mtx.*' -o -name '*.vec.*' \) \
+            -exec cp {} ref-dumps/ \;
+          ls -l ref-dumps
+          test -n "$(find ref-dumps -maxdepth 1 -type f | head -n 1)"
+
+      - name: Build kokkos with MINIFE_DEBUG
+        env:
+          JOBS: 2
+        run: |
+          make -C kokkos/src realclean KOKKOS_PATH="${GITHUB_WORKSPACE}/external/kokkos"
+          make -C kokkos/src -j$(nproc) \
+            KOKKOS_PATH="${GITHUB_WORKSPACE}/external/kokkos" \
+            MINIFE_INFO=0 \
+            MINIFE_KERNELS=0 \
+            CXXFLAGS='-O3 -DMINIFE_DEBUG'
+
+      - name: Run kokkos debug cases
+        run: |
+          rm -f ./*.mtx.* ./*.vec.*
+          ./kokkos/src/miniFE.x nx=${{ matrix.case.nx }} ny=${{ matrix.case.ny }} nz=${{ matrix.case.nz }}
+          mpirun --oversubscribe -np 2 ./kokkos/src/miniFE.x nx=${{ matrix.case.nx }} ny=${{ matrix.case.ny }} nz=${{ matrix.case.nz }}
+
+      - name: Collect kokkos dumps
+        run: |
+          rm -rf kokkos-dumps
+          mkdir -p kokkos-dumps
+          find . -maxdepth 1 -type f \
+            \( -name '*.mtx.*' -o -name '*.vec.*' \) \
+            -exec cp {} kokkos-dumps/ \;
+          ls -l kokkos-dumps
+          test -n "$(find kokkos-dumps -maxdepth 1 -type f | head -n 1)"
+
+      - name: Compare ref and kokkos dumps
+        run: |
+          ls ref-dumps
+          ls kokkos-dumps
+          diff -ru ref-dumps kokkos-dumps
+          echo "ref/ and kokkos/ MINIFE_DEBUG dumps match"

--- a/.github/workflows/compare-ref-kokkos.yml
+++ b/.github/workflows/compare-ref-kokkos.yml
@@ -49,7 +49,7 @@ jobs:
         run: |
           rm -f ./*.mtx.* ./*.vec.*
           ./ref/src/miniFE.x nx=${{ matrix.case.nx }} ny=${{ matrix.case.ny }} nz=${{ matrix.case.nz }}
-          mpirun -np 2 ./ref/src/miniFE.x nx=${{ matrix.case.nx }} ny=${{ matrix.case.ny }} nz=${{ matrix.case.nz }}
+          mpirun --oversubscribe -np 2 ./ref/src/miniFE.x nx=${{ matrix.case.nx }} ny=${{ matrix.case.ny }} nz=${{ matrix.case.nz }}
 
       - name: Collect ref dumps
         run: |

--- a/kokkos/src/Vector_functions.hpp
+++ b/kokkos/src/Vector_functions.hpp
@@ -65,7 +65,6 @@ void write_vector(const std::string& filename,
 
   typedef typename VectorType::ScalarType ScalarType;
 
-  const std::vector<ScalarType>& coefs = vec.coefs;
   for(int p=0; p<numprocs; ++p) {
     if (p == myproc) {
       if (p == 0) {
@@ -74,7 +73,7 @@ void write_vector(const std::string& filename,
   
       typename VectorType::GlobalOrdinalType first = vec.startIndex;
       for(size_t i=0; i<vec.local_size; ++i) {
-        ofs << first+i << " " << coefs[i] << std::endl;
+        ofs << first+i << " " << vec.coefs[i] << std::endl;
       }
     }
 #ifdef HAVE_MPI
@@ -191,4 +190,3 @@ typename TypeTraits<typename Vector::ScalarType>::magnitude_type
 }//namespace miniFE
 
 #endif
-

--- a/kokkos/src/cg_solve.hpp
+++ b/kokkos/src/cg_solve.hpp
@@ -159,7 +159,7 @@ cg_solve(OperatorType& A,
       oldrtrans = rtrans;
       TICK(); rtrans = dot(r, r); TOCK(tDOT);
       magnitude_type beta = rtrans/oldrtrans;
-      TICK(); waxpby(beta, p, one, r, p); TOCK(tWAXPY);
+      TICK(); waxpby(one, r, beta, p, p); TOCK(tWAXPY);
     }
     normr = std::sqrt(rtrans);
     if (myproc == 0 && (k%print_freq==0 || k==max_iter)) {
@@ -219,4 +219,3 @@ cg_solve(OperatorType& A,
 }//namespace miniFE
 
 #endif
-


### PR DESCRIPTION
This adds a CI job that does a serial+openmpi run and uses MINIFE_DEBUG to dump the raw values from inside the solver to compare the two implementations.

Along the way, two issues fixed:
1. The `kokkos/` dump thing was expecting `std::vector`, not `Kokkos::vector`
2. The use of `kokkos/` waxpy had a bug in the decomposed MPI case

With these changes, the internal vector/matrix states match before and after the solves.